### PR TITLE
Updates for compatibility with lein 2.1.0+

### DIFF
--- a/src/leiningen/package/artifact.clj
+++ b/src/leiningen/package/artifact.clj
@@ -38,7 +38,9 @@
     (if raw-artifacts
       (let [configured (for [entry raw-artifacts] (artifactify entry))
             pomjar #{"pom" "jar"}]
-        (filter #(or (not (:classifier %)) (not (pomjar (:extension %)))) configured)))))
+        (filter
+         #(or (:classifier %) (not (pomjar (:extension %))))
+         configured)))))
 
 (defn make-jar?
   [project]

--- a/src/leiningen/package/artifact.clj
+++ b/src/leiningen/package/artifact.clj
@@ -80,12 +80,21 @@
         artifacts (artifacts project)]
     (filter #(cond
                (exists? project %) %
-               (or autobuild (:autobuild %)) (or (build-artifact project %) true)
-               :else false) artifacts)))
+               (or autobuild (:autobuild %)) (or (build-artifact project %)
+                                                 true)
+               :else false)
+            artifacts)))
 
 (defn coordinates
-  ([project] [(symbol (:group project) (:name project)) (:version project)])
+  ([project]
+     [(symbol (:group project) (:name project)) (:version project)])
   ([project artifact & [suffix]]
-    (let [extension (str (:extension artifact) suffix)
-          classifier (if (:classifier artifact) [:classifier (:classifier artifact)])]
-    (vec (concat [(symbol (:group project) (:name project)) (:version project) :extension extension] classifier)))))
+     (let [extension (str (:extension artifact) suffix)
+           classifier (if (:classifier artifact)
+                        [:classifier (:classifier artifact)])]
+       (vec
+        (concat
+         [(symbol (:group project) (:name project))
+          (:version project)
+          :extension extension]
+         classifier)))))

--- a/src/leiningen/package/artifact.clj
+++ b/src/leiningen/package/artifact.clj
@@ -61,6 +61,7 @@
 
 (defn build-artifact
   [project artifact]
+  (main/debug "Building" (select-keys artifact [:extension :classifier]))
   (let [raw-args (twine/split (:build artifact) #"\s+")
         task-name (first raw-args)
         args (next raw-args)]

--- a/src/leiningen/package/hooks/deploy.clj
+++ b/src/leiningen/package/hooks/deploy.clj
@@ -17,7 +17,7 @@
     (if artifacts
       (do
         (package/clean project)
-        (let [jar-file (artifact/make-jar project)
+        (let [jar-file (val (first (artifact/make-jar project)))
               pom-file (pom/pom project)
               jar-coord (artifact/coordinates project artifact/jar)
               pom-coord (artifact/coordinates project artifact/pom)

--- a/src/leiningen/package/hooks/deploy.clj
+++ b/src/leiningen/package/hooks/deploy.clj
@@ -11,7 +11,7 @@
   (and (:sign-releases (second repo) true)
        (not (.endsWith ^String (:version project) "-SNAPSHOT"))))
 
-(defn deploy-files-for 
+(defn deploy-files-for
   [f project repo]
   (let [artifacts (artifact/artifacts project)]
     (if artifacts
@@ -22,24 +22,29 @@
               jar-coord (artifact/coordinates project artifact/jar)
               pom-coord (artifact/coordinates project artifact/pom)
               built-artifacts (artifact/built-artifacts project)
-              
+
               base-entries (if jar-file
                              {pom-coord pom-file jar-coord jar-file}
                              {pom-coord pom-file})
               entries (into base-entries
                             (for [artifact built-artifacts]
-                              [(artifact/coordinates project artifact) (artifact/file-path project artifact)]))
-              
-              base-signed (if (sign? project repo) 
+                              [(artifact/coordinates project artifact)
+                               (artifact/file-path project artifact)]))
+
+              base-signed (if (sign? project repo)
                             (if jar-file
-                              {(artifact/coordinates project artifact/pom ".asc") (leiningen.deploy/sign pom-file)
-                               (artifact/coordinates project artifact/jar ".asc") (leiningen.deploy/sign jar-file)}
-                              {(artifact/coordinates project artifact/pom ".asc") (leiningen.deploy/sign pom-file)}))
+                              {(artifact/coordinates project artifact/pom ".asc")
+                               (leiningen.deploy/sign pom-file)
+                               (artifact/coordinates project artifact/jar ".asc")
+                               (leiningen.deploy/sign jar-file)}
+                              {(artifact/coordinates project artifact/pom ".asc")
+                               (leiningen.deploy/sign pom-file)}))
               signed (if base-signed
                        (into base-signed
                              (for [artifact built-artifacts]
-                               [(artifact/coordinates project artifact ".asc") 
-                                (leiningen.deploy/sign (artifact/file-path project artifact))])))]
+                               [(artifact/coordinates project artifact ".asc")
+                                (leiningen.deploy/sign
+                                 (artifact/file-path project artifact))])))]
           (merge entries signed)))
       (f project repo))))
 

--- a/src/leiningen/package/hooks/install.clj
+++ b/src/leiningen/package/hooks/install.clj
@@ -14,7 +14,7 @@
     (if artifacts
       (do
         (package/clean project)
-        (let [jar-file (artifact/make-jar project)
+        (let [jar-file (val (first (artifact/make-jar project)))
               pom-file (pom/pom project)
               jar-coord (artifact/coordinates project)
               pom-coord (artifact/coordinates project artifact/pom)
@@ -25,11 +25,11 @@
                            {jar-coord jar-file pom-coord pom-file} 
                            {pom-coord pom-file})
               built-artifacts (artifact/built-artifacts project)
-              arts (concat base-coords 
-                           (for [artifact built-artifacts] (artifact/coordinates project artifact)))
-              files (into base-files 
-                          (for [artifact built-artifacts] [(artifact/coordinates project artifact) (artifact/file-path project artifact)]))]
-          (aether/install-artifacts :artifacts arts :files files)))
+              files (into base-files
+                          (for [artifact built-artifacts]
+                            [(artifact/coordinates project artifact)
+                             (artifact/file-path project artifact)]))]
+          (aether/install-artifacts :files files)))
       (f project))))
 
 (defn activate []

--- a/src/leiningen/package/hooks/install.clj
+++ b/src/leiningen/package/hooks/install.clj
@@ -18,11 +18,11 @@
               pom-file (pom/pom project)
               jar-coord (artifact/coordinates project)
               pom-coord (artifact/coordinates project artifact/pom)
-              base-coords (if jar-file 
-                            [jar-coord pom-coord] 
+              base-coords (if jar-file
+                            [jar-coord pom-coord]
                             [pom-coord])
-              base-files (if jar-file 
-                           {jar-coord jar-file pom-coord pom-file} 
+              base-files (if jar-file
+                           {jar-coord jar-file pom-coord pom-file}
                            {pom-coord pom-file})
               built-artifacts (artifact/built-artifacts project)
               files (into base-files


### PR DESCRIPTION
The plugin relies on the leiningen.jar/jar function, which unfortunately changed
it's return value in 2.1.0 and above.

Would be great to see the plugin pushed to clojars too, so the readme install
instructions would actually work.
