### PR TITLE
New features: allow build aliases and classified jars

### DIFF
--- a/src/leiningen/package/artifact.clj
+++ b/src/leiningen/package/artifact.clj
@@ -62,7 +62,7 @@
   (let [raw-args (twine/split (:build artifact) #"\s+")
         task-name (first raw-args)
         args (next raw-args)]
-    (main/apply-task task-name project args)))
+    (main/apply-task (main/lookup-alias task-name project) project args)))
 
 (defn build-artifacts
   [project artifacts]

--- a/src/leiningen/package/artifact.clj
+++ b/src/leiningen/package/artifact.clj
@@ -38,7 +38,9 @@
     (if raw-artifacts
       (let [configured (for [entry raw-artifacts] (artifactify entry))
             pomjar #{"pom" "jar"}]
-        (filter #(or (not (:classifier %)) (not (pomjar (:extension %)))) configured)))))
+        (filter #(or (and (:classifier %)
+                          (not= "pom" (:extension %)))
+                     (not (pomjar (:extension %)))) configured)))))
 
 (defn make-jar?
   [project]


### PR DESCRIPTION
Two minor new features:
- Allow the use of aliases as build tasks for artifacts.
- Allow the packaging of classified jars, e.g. to produce separate jars with test code.
