### PR TITLE
Document :classifier for artifacts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Configuring what packages are built, deployed, and installed.
            :artifacts [ ;; Collection of artifacts to build/package/install/deploy
              {:build "war" ;; Lein command used to build the artifact. e.g ring war, 
                            ;; ring uberwar, war, assemble
+              :classifier "standalone" ;; Optional classifier for the artifact,
+                                       ;; Use "standalone" for uberwar/uberjar
               :extension "war" ;; The extension/suffix that the artifact file can be 
                                ;; identified by. (:todo regex)}]}
 ```


### PR DESCRIPTION
Artifacts can have a :classifier. Deployment to nexus of uberwars only works when you add the "standalone" classifier.

I had to find this in the source code. Here's an update of the readme.
